### PR TITLE
Make events data consistent within the same event types

### DIFF
--- a/go/mobile/holder.go
+++ b/go/mobile/holder.go
@@ -18,9 +18,10 @@ type reqClaimStatusHandler struct {
 	BaseUrl string
 }
 
-type reqClaimStatusEvent struct {
+type resClaimStatusHandler struct {
 	Claim            *merkletree.Entry
 	CredentialTicket *Ticket
+	Status           string
 }
 
 type reqClaimCredentialHandler struct {
@@ -74,7 +75,12 @@ func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error) {
 	case issuerMsg.RequestStatusPending:
 		return false, "", nil
 	case issuerMsg.RequestStatusRejected:
-		j, err := json.Marshal(res)
+		event := resClaimStatusHandler{
+			Claim:            res.Claim,
+			CredentialTicket: nil,
+			Status:           string(res.Status),
+		}
+		j, err := json.Marshal(event)
 		if err != nil {
 			return true, "{}", err
 		}
@@ -95,9 +101,10 @@ func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error) {
 			return true, "{}", err
 		}
 		// Send event with received claim and credential request ticket
-		event := reqClaimStatusEvent{
+		event := resClaimStatusHandler{
 			Claim:            res.Claim,
 			CredentialTicket: ticket,
+			Status:           string(res.Status),
 		}
 		j, err := json.Marshal(event)
 		if err != nil {

--- a/go/mobile/holder_test.go
+++ b/go/mobile/holder_test.go
@@ -60,7 +60,7 @@ func (e *holderTestEvent) EventHandler(typ string, id, data string, err error) {
 	// Evaluate event
 	switch typ {
 	case "RequestClaimStatus":
-		d := &reqClaimStatusEvent{}
+		d := &resClaimStatusHandler{}
 		if err := json.Unmarshal([]byte(data), d); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
* Updated the function `func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error)` in a way that the returned string always represents the same json, when the returned bool = true and the returned err = nil.

Close #28 