### PR TITLE
Feature/singleticket

### DIFF
--- a/go/iden3mobile/identity.go
+++ b/go/iden3mobile/identity.go
@@ -106,8 +106,11 @@ func NewIdentity(storePath, pass, web3Url string, checkTicketsPeriodMilis int, e
 	); err != nil {
 		return nil, err
 	}
-	// Init claim DB
-	// cdb := NewClaimDB(storage.WithPrefix([]byte(credExisPrefix)))
+	// Init tickets
+	ts := NewTickets(storage.WithPrefix([]byte(ticketPrefix)))
+	if err := ts.Init(); err != nil {
+		return nil, err
+	}
 	// Verify that the Identity can be loaded successfully
 	keyStore.Close()
 	storage.Close()

--- a/go/iden3mobile/identity.go
+++ b/go/iden3mobile/identity.go
@@ -175,7 +175,7 @@ func (i *Identity) RequestClaim(baseUrl, data string) (*Ticket, error) {
 	id := uuid.New().String()
 	t := &Ticket{
 		Id:     id,
-		Type:   TicketTypeClaimStatus,
+		Type:   TicketTypeClaimReq,
 		Status: TicketStatusPending,
 	}
 	httpClient := httpclient.NewHttpClient(baseUrl)
@@ -186,9 +186,10 @@ func (i *Identity) RequestClaim(baseUrl, data string) (*Ticket, error) {
 	}), &res); err != nil {
 		return nil, err
 	}
-	t.handler = &reqClaimStatusHandler{
+	t.handler = &reqClaimHandler{
 		Id:      res.Id,
 		BaseUrl: baseUrl,
+		Status:  string(issuerMsg.RequestStatusPending),
 	}
 	err := i.Tickets.Add([]Ticket{*t})
 	return t, err

--- a/go/iden3mobile/tickets.go
+++ b/go/iden3mobile/tickets.go
@@ -25,8 +25,7 @@ type TicketType string
 type TicketStatus string
 
 const (
-	TicketTypeClaimStatus = "RequestClaimStatus"
-	TicketTypeClaimCred   = "RequestClaimCredential"
+	TicketTypeClaimReq    = "RequestClaim"
 	TicketTypeTest        = "test ticket"
 	TicketStatusDone      = "Done"
 	TicketStatusDoneError = "Done with error"
@@ -288,10 +287,8 @@ func (t *Ticket) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	switch t.Type {
-	case TicketTypeClaimStatus:
-		t.handler = &reqClaimStatusHandler{}
-	case TicketTypeClaimCred:
-		t.handler = &reqClaimCredentialHandler{}
+	case TicketTypeClaimReq:
+		t.handler = &reqClaimHandler{}
 	case TicketTypeTest:
 		t.handler = &testTicketHandler{}
 	default:

--- a/go/iden3mobile/tickets_test.go
+++ b/go/iden3mobile/tickets_test.go
@@ -142,21 +142,9 @@ func TestTicketSystem(t *testing.T) {
 	wgAsyncTest.Done()
 	require.Nil(t, ts2.Cancel("ts2 - remove1"))
 	wgAsyncTest.Done()
+	// Stop ticket system
 	stopTs1 <- true
 	stopTs2 <- true
-	// stopEv1 <- true
-	// stopEv2 <- true
-	// Load tickets
-	stopTs1 = make(chan bool)
-	// stopEv1 = make(chan bool)
-	ts1 = NewTickets(storage1)
-	// go eventHandler(eventCh1, stopEv1)
-	go ts1.CheckPending(nil, eventCh1, time.Duration(c.HolderTicketPeriod)*time.Millisecond, stopTs1)
-	stopTs2 = make(chan bool)
-	// stopEv2 = make(chan bool)
-	ts2 = NewTickets(storage2)
-	// go eventHandler(eventCh2, stopEv2)
-	go ts2.CheckPending(nil, eventCh2, time.Duration(c.HolderTicketPeriod)*time.Millisecond, stopTs2)
 	// Make after stop tickets finish
 	id1After1.handler = &testTicketHandler{SayImDone: true, Err: ""}
 	id2After1.handler = &testTicketHandler{SayImDone: true, Err: ""}
@@ -164,6 +152,13 @@ func TestTicketSystem(t *testing.T) {
 	id2After2.handler = &testTicketHandler{SayImDone: true, Err: "Something went wrong"}
 	require.Nil(t, ts1.Add([]Ticket{id1After1, id1After2}))
 	require.Nil(t, ts2.Add([]Ticket{id2After1, id2After2}))
+	// Restart ticket siatem
+	stopTs1 = make(chan bool)
+	ts1 = NewTickets(storage1)
+	go ts1.CheckPending(nil, eventCh1, time.Duration(c.HolderTicketPeriod)*time.Millisecond, stopTs1)
+	stopTs2 = make(chan bool)
+	ts2 = NewTickets(storage2)
+	go ts2.CheckPending(nil, eventCh2, time.Duration(c.HolderTicketPeriod)*time.Millisecond, stopTs2)
 	// After loading identity, tickets "Succes ticket after stop" and "Fail ticket after stop" will get resolved
 	// Cancel ticket remove2
 	require.Nil(t, ts1.Cancel("ts1 - remove2"))

--- a/go/iden3mobile/ticketshandlers.go
+++ b/go/iden3mobile/ticketshandlers.go
@@ -14,6 +14,12 @@ import (
 
 // TODO: async wrappers (with and without callback)
 
+type reqClaimHandler struct {
+	Id      int
+	BaseUrl string
+	Claim   *merkletree.Entry
+	DBkey   []byte
+}
 type resClaimStatusHandler struct {
 	Claim            *merkletree.Entry
 	CredentialTicket *Ticket
@@ -22,6 +28,11 @@ type resClaimStatusHandler struct {
 
 type reqClaimStatusHandler struct {
 	Id      int
+	BaseUrl string
+}
+
+type reqClaimCredentialHandler struct {
+	Claim   *merkletree.Entry
 	BaseUrl string
 }
 
@@ -78,11 +89,6 @@ func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error) {
 	default:
 		return true, "{}", errors.New("Unexpected response from issuer")
 	}
-}
-
-type reqClaimCredentialHandler struct {
-	Claim   *merkletree.Entry
-	BaseUrl string
 }
 
 func (h *reqClaimCredentialHandler) isDone(id *Identity) (bool, string, error) {

--- a/go/iden3mobile/ticketshandlers.go
+++ b/go/iden3mobile/ticketshandlers.go
@@ -35,7 +35,6 @@ func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error) {
 		fmt.Sprintf("claim/status/%v", h.Id)).Get(""), &res); err != nil {
 		return true, "{}", err
 	}
-	// TODO: returned "json" should be equal in all cases
 	switch res.Status {
 	case issuerMsg.RequestStatusPending:
 		return false, "", nil

--- a/go/iden3mobile/ticketshandlers.go
+++ b/go/iden3mobile/ticketshandlers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/iden3/go-iden3-core/components/httpclient"
 	"github.com/iden3/go-iden3-core/merkletree"
 	issuerMsg "github.com/iden3/go-iden3-servers-demo/servers/issuerdemo/messages"
@@ -19,25 +18,25 @@ type reqClaimHandler struct {
 	BaseUrl string
 	Claim   *merkletree.Entry
 	DBkey   []byte
-}
-type resClaimStatusHandler struct {
-	Claim            *merkletree.Entry
-	CredentialTicket *Ticket
-	Status           string
+	Status  string
 }
 
-type reqClaimStatusHandler struct {
-	Id      int
-	BaseUrl string
+type eventReqClaim struct {
+	Claim *merkletree.Entry
+	DBkey []byte
 }
 
-type reqClaimCredentialHandler struct {
-	Claim   *merkletree.Entry
-	BaseUrl string
+func (h *reqClaimHandler) isDone(id *Identity) (bool, string, error) {
+	if h.Status == string(issuerMsg.RequestStatusPending) {
+		return h.checkClaimStatus(id)
+	} else if h.Status == string(issuerMsg.ClaimtStatusNotYet) {
+		return h.checkClaimCredential(id)
+	}
+	return true, "", errors.New("Unexpected status, aborting claim request.")
 }
 
 //
-func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error) {
+func (h *reqClaimHandler) checkClaimStatus(id *Identity) (bool, string, error) {
 	httpClient := httpclient.NewHttpClient(h.BaseUrl)
 	var res issuerMsg.ResClaimStatus
 	// it's ok to remove ticket on a network error?
@@ -50,10 +49,9 @@ func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error) {
 	case issuerMsg.RequestStatusPending:
 		return false, "", nil
 	case issuerMsg.RequestStatusRejected:
-		event := resClaimStatusHandler{
-			Claim:            res.Claim,
-			CredentialTicket: nil,
-			Status:           string(res.Status),
+		event := eventReqClaim{
+			Claim: nil,
+			DBkey: nil,
 		}
 		j, err := json.Marshal(event)
 		if err != nil {
@@ -62,36 +60,15 @@ func (h *reqClaimStatusHandler) isDone(id *Identity) (bool, string, error) {
 		return true, string(j), nil
 	case issuerMsg.RequestStatusApproved:
 		// Create new ticket to handle credential request
-		ticket := &Ticket{
-			Id:     uuid.New().String(),
-			Type:   TicketTypeClaimCred,
-			Status: TicketStatusPending,
-			handler: &reqClaimCredentialHandler{
-				Claim:   res.Claim,
-				BaseUrl: h.BaseUrl,
-			},
-		}
-		// Add credential request ticket
-		if err := id.Tickets.Add([]Ticket{*ticket}); err != nil {
-			return true, "{}", err
-		}
-		// Send event with received claim and credential request ticket
-		event := resClaimStatusHandler{
-			Claim:            res.Claim,
-			CredentialTicket: ticket,
-			Status:           string(res.Status),
-		}
-		j, err := json.Marshal(event)
-		if err != nil {
-			return true, "{}", err
-		}
-		return true, string(j), nil
+		h.Claim = res.Claim
+		h.Status = string(issuerMsg.ClaimtStatusNotYet)
+		return false, "", nil
 	default:
 		return true, "{}", errors.New("Unexpected response from issuer")
 	}
 }
 
-func (h *reqClaimCredentialHandler) isDone(id *Identity) (bool, string, error) {
+func (h *reqClaimHandler) checkClaimCredential(id *Identity) (bool, string, error) {
 	httpClient := httpclient.NewHttpClient(h.BaseUrl)
 	res := issuerMsg.ResClaimCredential{}
 	// it's ok to remove ticket on a network error?
@@ -110,16 +87,24 @@ func (h *reqClaimCredentialHandler) isDone(id *Identity) (bool, string, error) {
 		if !h.Claim.Equal(res.Credential.Claim) {
 			err := errors.New("The received credential doesn't match the issued claim")
 			log.Error(err)
-			return true, "", err
+			return true, "{}", err
 		}
 		// Add credential to the identity
-		if _, err := id.ClaimDB.AddCredentialExistance(res.Credential); err != nil {
+		dbKey, err := id.ClaimDB.AddCredentialExistance(res.Credential)
+		if err != nil {
 			log.Error("Error storing credential existance", err)
-			return true, "", err
+			return true, "{}", err
 		}
 		// Send event with success
-		// TODO: return db key
-		return true, `{"success":true}`, nil
+		h.Status = string(issuerMsg.ClaimtStatusReady)
+		j, err := json.Marshal(eventReqClaim{
+			Claim: h.Claim,
+			DBkey: dbKey,
+		})
+		if err != nil {
+			return true, "{}", err
+		}
+		return true, string(j), nil
 	default:
 		return true, "{}", errors.New("Unexpected response from issuer")
 	}

--- a/go/iden3mobile/ticketshandlers_test.go
+++ b/go/iden3mobile/ticketshandlers_test.go
@@ -123,8 +123,14 @@ func TestHolder(t *testing.T) {
 	require.Nil(t, err)
 	// Prove claim
 	for i := 0; i < c.VerifierAttempts; i++ {
-		success1, _ := id1.ProveClaim(c.VerifierUrl, id1ClaimID[:])
-		success2, _ := id2.ProveClaim(c.VerifierUrl, id2ClaimID[:])
+		success1, err := id1.ProveClaim(c.VerifierUrl, id1ClaimID[:])
+		if err != nil {
+			log.Error("Error proving claim: ", err)
+		}
+		success2, err := id2.ProveClaim(c.VerifierUrl, id2ClaimID[:])
+		if err != nil {
+			log.Error("Error proving claim: ", err)
+		}
 		if success1 && success2 {
 			break
 		}

--- a/go/iden3mobile/ticketshandlers_test.go
+++ b/go/iden3mobile/ticketshandlers_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iden3/go-iden3-core/core/proof"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
+
+var id1ClaimID [32]byte
+var id2ClaimID [32]byte
+var eventFromId = 0
 
 func holderEventHandler(ev *Event) {
 	if ev.Err != nil {
@@ -26,24 +29,17 @@ func holderEventHandler(ev *Event) {
 	}
 	// Evaluate event
 	switch ev.Type {
-	case "RequestClaimStatus":
-		d := &resClaimStatusHandler{}
+	case TicketTypeClaimReq:
+		d := &eventReqClaim{}
 		if err := json.Unmarshal([]byte(ev.Data), d); err != nil {
 			panic(err)
 		}
-		// Check received data
-		if d.CredentialTicket.Type != "RequestClaimCredential" {
-			panic("Unexpected CredentialTicket type")
-		}
-		expectedEvents.Map[d.CredentialTicket.Id] = event{
-			Id:  d.CredentialTicket.Id,
-			Typ: d.CredentialTicket.Type,
-		}
-		// Wait for "RequestClaimCredential" event
-		return
-	case "RequestClaimCredential":
-		if ev.Data != `{"success":true}` {
-			panic("Validity credential not received")
+		if eventFromId == 1 {
+			copy(id1ClaimID[:], d.DBkey)
+		} else if eventFromId == 2 {
+			copy(id2ClaimID[:], d.DBkey)
+		} else {
+			panic("Event from unexpected identity")
 		}
 		return
 	default:
@@ -51,7 +47,7 @@ func holderEventHandler(ev *Event) {
 	}
 }
 
-func TestHolder(t *testing.T) {
+func TestHolderHandlers(t *testing.T) {
 	expectedEvents = eventsMap{
 		Map: make(map[string]event),
 	}
@@ -70,12 +66,10 @@ func TestHolder(t *testing.T) {
 	// Request claim
 	t1, err := id1.RequestClaim(c.IssuerUrl, id1.id.ID().String())
 	require.Nil(t, err)
-	log.Info("--- TEST LOG: RequestClaim. Ticket: ", t1, ". Error: ", err)
 	expectedEvents.Map[t1.Id] = event{Typ: t1.Type}
 
 	t2, err := id2.RequestClaim(c.IssuerUrl, id2.id.ID().String())
 	require.Nil(t, err)
-	log.Info("--- TEST LOG: RequestClaim. Ticket: ", t2, ". Error: ", err)
 	expectedEvents.Map[t2.Id] = event{Typ: t2.Type}
 	// Test that tickets are persisted by reloading identities
 	id1.Stop()
@@ -85,42 +79,10 @@ func TestHolder(t *testing.T) {
 	id2, err = NewIdentityLoad(dir2, "pass_TestHolder2", c.Web3Url, c.HolderTicketPeriod)
 	require.Nil(t, err)
 	// Wait for the events that will get triggered on issuer response
-	holderEventHandler(id1.GetNextEvent()) // Wait until the issuer response produce event (claim aproved)
-	holderEventHandler(id2.GetNextEvent()) // Wait until the issuer response produce event (claim aproved)
-	holderEventHandler(id1.GetNextEvent()) // Wait until the issuer response produce event (claim issued)
-	holderEventHandler(id2.GetNextEvent()) // Wait until the issuer response produce event (claim issued)
-	log.Info("--- TEST LOG: Claims received!")
-	// If events don't cause panic everything went as expected. Check that identities have one claim.
-	// Do it after reload identities to test claim persistance
-	err = id1.ClaimDB.Iterate_(func(id []byte, cred *proof.CredentialExistence) (bool, error) {
-		return false, nil
-	})
-	require.Nil(t, err)
-	id1.Stop()
-	id2.Stop()
-	id1, err = NewIdentityLoad(dir1, "pass_TestHolder1", c.Web3Url, c.HolderTicketPeriod)
-	require.Nil(t, err)
-	id2, err = NewIdentityLoad(dir2, "pass_TestHolder2", c.Web3Url, c.HolderTicketPeriod)
-	require.Nil(t, err)
-
-	var id1ClaimID [32]byte
-	err = id1.ClaimDB.Iterate_(func(id []byte, cred *proof.CredentialExistence) (bool, error) {
-		copy(id1ClaimID[:], id)
-		return false, nil
-	})
-	require.Nil(t, err)
-	require.NotEqual(t, [32]byte{}, id1ClaimID)
-	_, err = id1.ClaimDB.GetReceivedClaim(id1ClaimID[:])
-	require.Nil(t, err)
-	var id2ClaimID [32]byte
-	err = id2.ClaimDB.Iterate_(func(id []byte, cred *proof.CredentialExistence) (bool, error) {
-		copy(id2ClaimID[:], id)
-		return false, nil
-	})
-	require.Nil(t, err)
-	require.NotEqual(t, [32]byte{}, id2ClaimID)
-	_, err = id2.ClaimDB.GetReceivedClaim(id2ClaimID[:])
-	require.Nil(t, err)
+	eventFromId = 1
+	holderEventHandler(id1.GetNextEvent()) // Wait until the issuer response produce event
+	eventFromId = 2
+	holderEventHandler(id2.GetNextEvent()) // Wait until the issuer response produce event
 	// Prove claim
 	for i := 0; i < c.VerifierAttempts; i++ {
 		success1, err := id1.ProveClaim(c.VerifierUrl, id1ClaimID[:])
@@ -136,7 +98,6 @@ func TestHolder(t *testing.T) {
 		}
 		time.Sleep(time.Duration(c.VerifierRetryPeriod) * time.Second)
 	}
-	// Wait for the callback response.
 	id1.Stop()
 	id2.Stop()
 }


### PR DESCRIPTION
* Always store tickets, even when not solved. Close #40 
* Persist ticket cancellation so the app can be closed at any time without losing this info
* Handle claim request with a single ticket (instead of two). Close #43 