### PR TITLE
Use strings in ClaimDB keys

### DIFF
--- a/go/iden3mobile/claimsdb_test.go
+++ b/go/iden3mobile/claimsdb_test.go
@@ -59,50 +59,42 @@ func TestClaimDB(t *testing.T) {
 	id2, err := cdb.AddCredentialExistance(&cred2)
 	require.Nil(t, err)
 
-	cred1Cpy, err := cdb.GetReceivedCredential(id1)
+	cred1Cpy, err := cdb.GetCredExist(id1)
 	require.Nil(t, err)
 	require.Equal(t, cred1.Id, cred1Cpy.Id)
 	require.Equal(t, cred1.Claim.Data, cred1Cpy.Claim.Data)
 
-	cred2Cpy, err := cdb.GetReceivedCredential(id2)
+	cred2Cpy, err := cdb.GetCredExist(id2)
 	require.Nil(t, err)
 	require.Equal(t, cred2.Id, cred2Cpy.Id)
 	require.Equal(t, cred2.Claim.Data, cred2Cpy.Claim.Data)
 
-	creds := make(map[[32]byte]*proof.CredentialExistence)
-	err = cdb.Iterate_(func(id []byte, cred *proof.CredentialExistence) (bool, error) {
-		var id32 [32]byte
-		copy(id32[:], id)
-		creds[id32] = cred
+	creds := make(map[string]*proof.CredentialExistence)
+	err = cdb.Iterate_(func(id string, cred *proof.CredentialExistence) (bool, error) {
+		creds[id] = cred
 		return true, nil
 	})
 	require.Nil(t, err)
-	var id132 [32]byte
-	copy(id132[:], id1)
-	require.Equal(t, &cred1, creds[id132])
-	var id232 [32]byte
-	copy(id232[:], id2)
-	require.Equal(t, &cred2, creds[id232])
+	require.Equal(t, &cred1, creds[id1])
+	require.Equal(t, &cred2, creds[id2])
 
-	credsJSON := make(map[[32]byte]string)
-	err = cdb.IterateCredExistJSON_(func(id []byte, cred string) (bool, error) {
-		var id32 [32]byte
-		copy(id32[:], id)
-		credsJSON[id32] = cred
+	credsJSON := make(map[string]string)
+	err = cdb.IterateCredExistJSON_(func(id string, cred string) (bool, error) {
+		credsJSON[id] = cred
 		return true, nil
 	})
+	require.Nil(t, err)
 	require.Equal(t, 2, len(credsJSON))
 	for k, v := range credsJSON {
 		fmt.Printf("credJSON %v: %v\n", common.Hex(k[:]), v)
 	}
 
-	claimsJSON := make(map[[32]byte]string)
-	err = cdb.IterateClaimsJSON_(func(id []byte, claim string) (bool, error) {
-		var id32 [32]byte
-		copy(id32[:], id)
-		claimsJSON[id32] = claim
+	claimsJSON := make(map[string]string)
+	err = cdb.IterateClaimsJSON_(func(id string, claim string) (bool, error) {
+		claimsJSON[id] = claim
 		return true, nil
 	})
+	require.Nil(t, err)
 	require.Equal(t, 2, len(claimsJSON))
 	for k, v := range claimsJSON {
 		fmt.Printf("claimsJSON %v: %v\n", common.Hex(k[:]), v)

--- a/go/iden3mobile/identity.go
+++ b/go/iden3mobile/identity.go
@@ -258,10 +258,10 @@ func (i *Identity) RequestClaimWithCb(baseUrl, data string, c CallbackRequestCla
 
 // ProveCredential sends a credentialValidity build from the given credentialExistance to a verifier
 // the callback is used to check if the verifier has accepted the credential as valid
-func (i *Identity) ProveClaim(baseUrl string, credId []byte) (bool, error) {
+func (i *Identity) ProveClaim(baseUrl string, credID string) (bool, error) {
 	// TODO: add context
 	// Get credential existance
-	credExis, err := i.ClaimDB.GetReceivedCredential(credId)
+	credExis, err := i.ClaimDB.GetCredExist(credID)
 	if err != nil {
 		return false, err
 	}
@@ -287,6 +287,6 @@ type CallbackProveClaim interface {
 	Fn(bool, error)
 }
 
-func (i *Identity) ProveClaimWithCb(baseUrl string, credId []byte, c CallbackProveClaim) {
-	go func() { c.Fn(i.ProveClaim(baseUrl, credId)) }()
+func (i *Identity) ProveClaimWithCb(baseUrl string, credID string, c CallbackProveClaim) {
+	go func() { c.Fn(i.ProveClaim(baseUrl, credID)) }()
 }

--- a/go/iden3mobile/ticketshandlers.go
+++ b/go/iden3mobile/ticketshandlers.go
@@ -16,13 +16,13 @@ type reqClaimHandler struct {
 	Id      int
 	BaseUrl string
 	Claim   *merkletree.Entry
-	DBkey   []byte
+	CredID  string
 	Status  string
 }
 
 type eventReqClaim struct {
-	Claim *merkletree.Entry
-	DBkey []byte
+	Claim  *merkletree.Entry
+	CredID string
 }
 
 func (h *reqClaimHandler) isDone(id *Identity) (bool, string, error) {
@@ -49,8 +49,8 @@ func (h *reqClaimHandler) checkClaimStatus(id *Identity) (bool, string, error) {
 		return false, "", nil
 	case issuerMsg.RequestStatusRejected:
 		event := eventReqClaim{
-			Claim: nil,
-			DBkey: nil,
+			Claim:  nil,
+			CredID: "",
 		}
 		j, err := json.Marshal(event)
 		if err != nil {
@@ -89,7 +89,7 @@ func (h *reqClaimHandler) checkClaimCredential(id *Identity) (bool, string, erro
 			return true, "{}", err
 		}
 		// Add credential to the identity
-		dbKey, err := id.ClaimDB.AddCredentialExistance(res.Credential)
+		credID, err := id.ClaimDB.AddCredentialExistance(res.Credential)
 		if err != nil {
 			log.Error("Error storing credential existance", err)
 			return true, "{}", err
@@ -97,8 +97,8 @@ func (h *reqClaimHandler) checkClaimCredential(id *Identity) (bool, string, erro
 		// Send event with success
 		h.Status = string(issuerMsg.ClaimtStatusReady)
 		j, err := json.Marshal(eventReqClaim{
-			Claim: h.Claim,
-			DBkey: dbKey,
+			Claim:  h.Claim,
+			CredID: credID,
 		})
 		if err != nil {
 			return true, "{}", err


### PR DESCRIPTION
Entries in the ClaimDB are now indexed by a string (CredID).  This makes the
API cleaner, specially when stuff is encoded in JSON and back.

The following changes have been made:
- ClaimDB.GetReceivedCredential renamed to ClaimDB.GetCredExist
- ClaimDB.GetReceivedClaim updated to use the JSON format of the claim with metadata
- ClaimDB.GetReceivedClaim renamed to ClaimDB.GetCredExistJSON
- Added ClaimDB.GetClaimJSON

Resolve #58